### PR TITLE
drop netcoreapp2.1 support

### DIFF
--- a/src/UnitTests/FactsBase.cs
+++ b/src/UnitTests/FactsBase.cs
@@ -20,20 +20,12 @@ namespace OpenServiceBroker
         {
             _server = new TestServer(
                 new WebHostBuilder()
-#if NETCOREAPP2_1
-                   .ConfigureServices(x
-                        => x.AddTransient(_ => Mock.Object)
-                            .AddMvc()
-                            .AddOpenServiceBroker())
-                   .Configure(x => x.UseMvc()));
-#else
                    .ConfigureServices(x
                         => x.AddScoped(_ => Mock.Object)
                             .AddControllers()
                             .AddOpenServiceBroker())
                    .Configure(x => x.UseRouting()
                                     .UseEndpoints(endpoints => endpoints.MapControllers())));
-#endif
             Client = new OpenServiceBrokerClient(_server.CreateClient(), new Uri("http://localhost"));
         }
 

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Project properties -->
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>
     <DeterministicSourcePaths>False</DeterministicSourcePaths>
@@ -29,10 +29,6 @@
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.2.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.21" />


### PR DESCRIPTION
The target framework 'netcoreapp2.1' is out of support and will not
receive security updates in the future. Please refer to
https://aka.ms/dotnet-core-support for more information about the
support policy.

Signed-off-by: Matthew Fisher <matt.fisher@fermyon.com>